### PR TITLE
ensure connections are not proxied for probes

### DIFF
--- a/vendor/k8s.io/kubernetes/pkg/probe/http/http.go
+++ b/vendor/k8s.io/kubernetes/pkg/probe/http/http.go
@@ -36,9 +36,13 @@ func New() HTTPProber {
 	return NewWithTLSConfig(tlsConfig)
 }
 
+func ensureNoProxy(req *http.Request) (*url.URL, error) {
+	return req.URL, nil
+}
+
 // NewWithTLSConfig takes tls config as parameter.
 func NewWithTLSConfig(config *tls.Config) HTTPProber {
-	transport := utilnet.SetTransportDefaults(&http.Transport{TLSClientConfig: config, DisableKeepAlives: true})
+	transport := utilnet.SetTransportDefaults(&http.Transport{Proxy: ensureNoProxy, TLSClientConfig: config, DisableKeepAlives: true})
 	return httpProber{transport}
 }
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1618311
Disables proxying connections to internal IPs for liveness
and readiness probes.

Opening here first to gather feedback.

cc @soltysh @deads2k 